### PR TITLE
必须从字符串最前面开始匹配，因为有时候html属性中有html标签，例如 <img alt="S与K<SUB>I</SUB>之间的关系">

### DIFF
--- a/src/parser/dom.js
+++ b/src/parser/dom.js
@@ -53,7 +53,7 @@ function collectTags(structure,template) {
     })
     structure.end++
 
-    if (/<\/\w+/.test(match)) {
+    if (/^<\/\w+/.test(match)) {
       structure[structure.end].isEnd = true
     } else if (attrString !== '') {
       structure[structure.end].attrs = analyzeAttributes(attrString)


### PR DESCRIPTION
必须从html标签字符串最前面开始匹配tag，因为有时候html属性中还有html标签，例如
```html
<img alt="S与K<SUB>I</SUB>之间的关系">
```